### PR TITLE
Add a `mini` reactive framework and a widget inspector

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -6,3 +6,6 @@ rustflags = [
     "-Aclippy::single_match",
     "-Aclippy::bool_assert_comparison",
 ]
+
+[profile.release]
+debug = true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1438,8 +1438,10 @@ dependencies = [
  "open",
  "piet-common",
  "pulldown-cmark",
+ "scoped-tls",
  "serde",
  "serde_json",
+ "slotmap",
  "smallvec",
  "tempfile",
  "tracing",
@@ -1950,9 +1952,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.46"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94e2ef8dbfc347b10c094890f778ee2e36ca9bb4262e86dc99cd217e35f3470b"
+checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
  "unicode-ident",
 ]
@@ -2186,6 +2188,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
 name = "scoped_threadpool"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2331,6 +2339,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "slotmap"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbff4acf519f630b3a3ddcfaea6c06b42174d9a44bc70c620e9ed1649d58b82a"
+dependencies = [
+ "version_check",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,8 @@ image = "0.24.0"
 once_cell = "1.9.0"
 serde = {version = "1.0.133", features = ["derive"]}
 serde_json = "1.0.74"
+scoped-tls = "1.0.1"
+slotmap = "1.0.7"
 
 [target.'cfg(target_arch="wasm32")'.dependencies]
 console_error_panic_hook = {version = "0.1.6"}

--- a/examples/inspector.rs
+++ b/examples/inspector.rs
@@ -1,0 +1,70 @@
+// This software is licensed under Apache License 2.0 and distributed on an
+// "as-is" basis without warranties of any kind. See the LICENSE file for
+// details.
+
+//! This is a very small example of how to use the widget inspector.
+
+// On Windows platform, don't show a console when opening the app.
+#![windows_subsystem = "windows"]
+
+use masonry::command::INSPECT;
+use masonry::widget::{prelude::*, SizedBox};
+use masonry::widget::{Button, Flex, Label};
+use masonry::{Action, Target};
+use masonry::{AppDelegate, DelegateCtx};
+use masonry::{AppLauncher, WindowDescription, WindowId};
+
+const VERTICAL_WIDGET_SPACING: f64 = 20.0;
+
+struct Delegate;
+
+impl AppDelegate for Delegate {
+    fn on_action(
+        &mut self,
+        _ctx: &mut DelegateCtx,
+        _window_id: WindowId,
+        _widget_id: WidgetId,
+        action: Action,
+        _env: &Env,
+    ) {
+        if let Action::ButtonPressed = action {
+            _ctx.get_external_handle()
+                .submit_command(INSPECT, Box::new(()), Target::Window(_window_id))
+                .unwrap();
+        }
+    }
+}
+
+pub fn main() {
+    std::thread::Builder::new()
+        .stack_size(32 * 1024 * 1024)
+        .spawn(|| {
+            // describe the main window
+            let main_window = WindowDescription::new(build_root_widget())
+                .title("Hello World!")
+                .window_size((600.0, 400.0));
+
+            // start the application. Here we pass in the application state.
+            AppLauncher::with_window(main_window)
+                .with_delegate(Delegate)
+                .log_to_console()
+                .launch()
+                .expect("Failed to launch application");
+        })
+        .unwrap()
+        .join()
+        .unwrap();
+}
+
+fn build_root_widget() -> impl Widget {
+    let label = Label::new("Hello").with_text_size(32.0);
+
+    // a button that says "Inspect"
+    let button = SizedBox::new(Button::new("Inspect"));
+
+    // arrange the two widgets vertically, with some padding
+    Flex::column()
+        .with_child(label)
+        .with_spacer(VERTICAL_WIDGET_SPACING)
+        .with_child(button)
+}

--- a/src/command.rs
+++ b/src/command.rs
@@ -270,6 +270,9 @@ mod sys {
     /// Select all.
     pub const SELECT_ALL: Selector = Selector::new("masonry-builtin.menu-select-all");
 
+    /// Inspect the window.
+    pub const INSPECT: Selector = Selector::new("masonry-builtin.inspect");
+
     /// Text input state has changed, and we need to notify the platform.
     pub(crate) const INVALIDATE_IME: Selector<ImeInvalidation> =
         Selector::new("masonry-builtin.invalidate-ime");

--- a/src/env.rs
+++ b/src/env.rs
@@ -63,7 +63,7 @@ pub struct Key<T> {
 impl<T> Clone for Key<T> {
     fn clone(&self) -> Self {
         Self {
-            key: self.key.clone(),
+            key: self.key,
             value_type: self.value_type.clone(),
         }
     }

--- a/src/inspector.rs
+++ b/src/inspector.rs
@@ -1,0 +1,712 @@
+use crate::command::{CommandQueue, INSPECT};
+use crate::mini::reactive::{
+    create_effect, create_rw_signal, update_widget, RuntimeView, RwSignal, CURRENT_RUNTIME,
+};
+use crate::mini::style::{LIGHT_GRAY, WHITE_SMOKE};
+use crate::mini::view::{AnyView, View};
+use crate::mini::views::{
+    button, container, dyn_container, empty, h_stack, scroll, text, v_stack, v_stack_from_iter,
+    z_stack_from_iter,
+};
+use crate::widget::{SizedBox, Stack, WidgetRef};
+use crate::{
+    BackgroundBrush, BoxConstraints, Command, Env, Event, EventCtx, LayoutCtx, LifeCycle,
+    LifeCycleCtx, PaintCtx, StatusChange, Target, WidgetId, WindowId,
+};
+use crate::{Widget, WidgetPod};
+use piet_common::kurbo::{Point, Rect, Size};
+use piet_common::Color;
+use smallvec::SmallVec;
+use std::any::Any;
+use std::cell::RefCell;
+use std::fmt::Display;
+use std::{rc::Rc, time::Instant};
+
+type Id = WidgetId;
+
+#[derive(Clone, Debug)]
+pub struct CapturedView {
+    id: Id,
+    name: String,
+    layout: Rect,
+    clipped: Rect,
+    children: Vec<Rc<CapturedView>>,
+    keyboard_navigable: bool,
+    focused: bool,
+}
+
+impl CapturedView {
+    pub fn capture(widget: WidgetRef<'_, dyn Widget>, clip: Rect) -> Self {
+        let id = widget.state().id;
+        let layout = widget.state().window_layout_rect();
+        let keyboard_navigable = false;
+        let focused = false;
+        let clipped = layout.intersect(clip);
+        Self {
+            id,
+            name: widget.short_type_name().to_string(),
+            layout,
+            clipped,
+            keyboard_navigable,
+            focused,
+            children: widget
+                .children()
+                .into_iter()
+                .map(|view| Rc::new(CapturedView::capture(view, clipped)))
+                .collect(),
+        }
+    }
+
+    fn find(&self, id: Id) -> Option<&CapturedView> {
+        if self.id == id {
+            return Some(self);
+        }
+        self.children
+            .iter()
+            .filter_map(|child| child.find(id))
+            .next()
+    }
+
+    fn find_by_pos(&self, pos: Point) -> Option<&CapturedView> {
+        self.children
+            .iter()
+            .rev()
+            .filter_map(|child| child.find_by_pos(pos))
+            .next()
+            .or_else(|| self.clipped.contains(pos).then_some(self))
+    }
+
+    fn warnings(&self) -> bool {
+        self.children.iter().any(|child| child.warnings())
+    }
+}
+
+struct Capture {
+    root: Rc<CapturedView>,
+    start: Instant,
+    post_layout: Instant,
+    end: Instant,
+    window_size: Size,
+    window_id: WindowId,
+    background: Color,
+}
+
+fn captured_view_name(view: &CapturedView) -> View<impl Widget> {
+    let name = text(view.name.clone());
+    let id = text(view.id.to_raw()).style(|s| {
+        s.margin_right(5.0)
+            .background(Color::BLACK.with_alpha(0.02))
+            .border(1.0)
+            .border_radius(5.0)
+            .border_color(Color::BLACK.with_alpha(0.07))
+            .padding(3.0)
+            .padding_top(0.0)
+            .padding_bottom(0.0)
+            .font_size(12.0)
+            .color(Color::BLACK.with_alpha(0.6))
+    });
+    let tab = if view.focused {
+        text("Focus")
+            .style(|s| {
+                s.margin_right(5.0)
+                    .background(Color::rgb8(63, 81, 101).with_alpha(0.6))
+                    .border_radius(5.0)
+                    .padding(1.0)
+                    .font_size(10.0)
+                    .color(Color::WHITE.with_alpha(0.8))
+            })
+            .any()
+    } else if view.keyboard_navigable {
+        text("Tab")
+            .style(|s| {
+                s.margin_right(5.0)
+                    .background(Color::rgb8(204, 217, 221).with_alpha(0.4))
+                    .border(1.0)
+                    .border_radius(5.0)
+                    .border_color(Color::BLACK.with_alpha(0.07))
+                    .padding(1.0)
+                    .font_size(10.0)
+                    .color(Color::BLACK.with_alpha(0.4))
+            })
+            .any()
+    } else {
+        empty().any()
+    };
+    h_stack((id, tab, name)).style(|s| s.items_center())
+}
+
+// Outlined to reduce stack usage.
+#[inline(never)]
+fn captured_view_no_children(
+    view: &CapturedView,
+    depth: usize,
+    capture_view: &CaptureView,
+) -> AnyView {
+    let offset = depth as f64 * 14.0;
+    let name = captured_view_name(view);
+    let name_id = name.id();
+    let height = 20.0;
+    let id = view.id;
+    let selected = capture_view.selected;
+    let highlighted = capture_view.highlighted;
+
+    let row = h_stack((empty().style(move |s| s.width(12.0 + offset)), name))
+        .style(move |s| {
+            s.hover(move |s| {
+                s.background(Color::rgba8(228, 237, 216, 160))
+                    .apply_if(selected.get() == Some(id), |s| {
+                        s.background(Color::rgb8(186, 180, 216))
+                    })
+            })
+            .height(height)
+            .apply_if(highlighted.get() == Some(id), |s| {
+                s.background(Color::rgba8(228, 237, 216, 160))
+            })
+            .apply_if(selected.get() == Some(id), |s| {
+                if highlighted.get() == Some(id) {
+                    s.background(Color::rgb8(186, 180, 216))
+                } else {
+                    s.background(Color::rgb8(213, 208, 216))
+                }
+            })
+        })
+        .on_click(move |_| selected.set(Some(id)))
+        .on_enter(move || highlighted.set(Some(id)))
+        .any();
+
+    let row_id = row.id();
+    let scroll_to = capture_view.scroll_to;
+    let expanding_selection = capture_view.expanding_selection;
+    create_effect(move || {
+        if let Some(selection) = expanding_selection.get() {
+            if selection == id {
+                // Scroll to the row, then to the name part of the row.
+                scroll_to.set(Some(row_id));
+                scroll_to.set(Some(name_id));
+            }
+        }
+    });
+
+    row
+}
+
+// Outlined to reduce stack usage.
+#[inline(never)]
+fn captured_view_with_children(
+    view: &Rc<CapturedView>,
+    depth: usize,
+    capture_view: &CaptureView,
+    children: Vec<AnyView>,
+) -> AnyView {
+    let offset = depth as f64 * 14.0;
+    let name = captured_view_name(view);
+    let height = 20.0;
+    let id = view.id;
+    let selected = capture_view.selected;
+    let highlighted = capture_view.highlighted;
+    let expanding_selection = capture_view.expanding_selection;
+    let view_ = view.clone();
+
+    let expanded = create_rw_signal(true);
+
+    let name_id = name.id();
+    let row = h_stack((
+        empty().style(move |s| s.width(offset)),
+        empty()
+            .style(move |s| {
+                s.background(if expanded.get() {
+                    Color::WHITE.with_alpha(0.3)
+                } else {
+                    Color::BLACK.with_alpha(0.3)
+                })
+                .border(1.0)
+                .width(12.0)
+                .height(12.0)
+                .margin_left(offset)
+                .margin_right(4.0)
+                .border_color(Color::BLACK.with_alpha(0.4))
+                .border_radius(4.0)
+                .hover(move |s| {
+                    s.border_color(Color::BLACK.with_alpha(0.6))
+                        .background(if expanded.get() {
+                            Color::WHITE.with_alpha(0.5)
+                        } else {
+                            Color::BLACK.with_alpha(0.5)
+                        })
+                })
+            })
+            .on_click(move |_| {
+                expanded.set(!expanded.get());
+            }),
+        name,
+    ))
+    .style(move |s| {
+        s.padding_left(3.0)
+            .items_center()
+            .hover(move |s| {
+                s.background(Color::rgba8(228, 237, 216, 160))
+                    .apply_if(selected.get() == Some(id), |s| {
+                        s.background(Color::rgb8(186, 180, 216))
+                    })
+            })
+            .height(height)
+            .apply_if(highlighted.get() == Some(id), |s| {
+                s.background(Color::rgba8(228, 237, 216, 160))
+            })
+            .apply_if(selected.get() == Some(id), |s| {
+                if highlighted.get() == Some(id) {
+                    s.background(Color::rgb8(186, 180, 216))
+                } else {
+                    s.background(Color::rgb8(213, 208, 216))
+                }
+            })
+    })
+    .on_click(move |_| selected.set(Some(id)))
+    .on_enter(move || highlighted.set(Some(id)));
+
+    let row_id = row.id();
+    let scroll_to = capture_view.scroll_to;
+    create_effect(move || {
+        if let Some(selection) = expanding_selection.get() {
+            if selection != id && view_.find(selection).is_some() {
+                expanded.set(true);
+            }
+            if selection == id {
+                // Scroll to the row, then to the name part of the row.
+                scroll_to.set(Some(row_id));
+                scroll_to.set(Some(name_id));
+            }
+        }
+    });
+
+    let child_count = children.len();
+
+    let line = empty().style(move |s| {
+        let line = if expanded.get() {
+            child_count as f64 * 20.0
+        } else {
+            0.0
+        };
+        s.absolute()
+            .height(line)
+            .width(1.0)
+            .margin_left(9.0 + offset)
+            .background(Color::BLACK.with_alpha(0.1))
+    });
+    let line = h_stack((empty().style(move |s| s.width(5.0 + offset)), line));
+
+    let list = v_stack_from_iter(children).style(move |s| s.display(expanded.get()).items_start());
+
+    let list = z_stack_from_iter([
+        (line.any(), WidgetId::next(), Point::ZERO),
+        (list.any(), WidgetId::next(), Point::ZERO),
+    ]);
+
+    v_stack((row, list)).style(|s| s.items_start()).any()
+}
+
+fn captured_view(view: &Rc<CapturedView>, depth: usize, capture_view: &CaptureView) -> AnyView {
+    if view.children.is_empty() {
+        captured_view_no_children(view, depth, capture_view)
+    } else {
+        let children: Vec<_> = view
+            .children
+            .iter()
+            .map(|view| captured_view(view, depth + 1, capture_view))
+            .collect();
+        captured_view_with_children(view, depth, capture_view, children)
+    }
+}
+
+pub(crate) fn header(label: impl Display) -> View<impl Widget> {
+    text(label).style(|s| {
+        s.padding(5.0)
+            .background(WHITE_SMOKE)
+            .width_full()
+            .height(27.0)
+            .border_bottom(1.0)
+            .border_color(LIGHT_GRAY)
+    })
+}
+
+fn info(name: impl Display, value: String) -> View<impl Widget> {
+    info_row(name.to_string(), text(value))
+}
+
+fn info_row(name: String, view: View<impl Any>) -> View<impl Widget> {
+    h_stack((
+        container(text(name).style(|s| s.margin_right(5.0).color(Color::BLACK.with_alpha(0.6))))
+            .style(|s| s.min_width(150.0).flex_row_reverse()),
+        view,
+    ))
+    .style(|s| {
+        s.padding(5.0)
+            .hover(|s| s.background(Color::rgba8(228, 237, 216, 160)))
+    })
+}
+
+fn stats(capture: &Capture) -> View<impl Widget> {
+    let layout_time = capture.post_layout.saturating_duration_since(capture.start);
+    let paint_time = capture.end.saturating_duration_since(capture.post_layout);
+    let layout_time = info(
+        "Layout Time",
+        format!("{:.4} ms", layout_time.as_secs_f64() * 1000.0),
+    );
+    let paint_time = info(
+        "Paint Time",
+        format!("{:.4} ms", paint_time.as_secs_f64() * 1000.0),
+    );
+    let w = info("Window Width", format!("{}", capture.window_size.width));
+    let h = info("Window Height", format!("{}", capture.window_size.height));
+    v_stack((layout_time, paint_time, w, h))
+}
+
+fn selected_view(capture: &Rc<Capture>, selected: RwSignal<Option<Id>>) -> AnyView {
+    let capture = capture.clone();
+    dyn_container(
+        move || selected.get(),
+        move |current| {
+            if let Some(view) = current.and_then(|id| capture.root.find(id)) {
+                let name = info("Type", view.name.clone());
+                let id = info("Id", view.id.to_raw().to_string());
+                let count = info("Child Count", format!("{}", view.children.len()));
+                let beyond = |view: f64, window| {
+                    if view > window {
+                        format!(" ({} after window edge)", view - window)
+                    } else if view < 0.0 {
+                        format!(" ({} before window edge)", -view)
+                    } else {
+                        String::new()
+                    }
+                };
+                let x = info(
+                    "X",
+                    format!(
+                        "{}{}",
+                        view.layout.x0,
+                        beyond(view.layout.x0, capture.window_size.width)
+                    ),
+                );
+                let y = info(
+                    "Y",
+                    format!(
+                        "{}{}",
+                        view.layout.y0,
+                        beyond(view.layout.y0, capture.window_size.height)
+                    ),
+                );
+                let w = info(
+                    "Width",
+                    format!(
+                        "{}{}",
+                        view.layout.width(),
+                        beyond(view.layout.x1, capture.window_size.width)
+                    ),
+                );
+                let h = info(
+                    "Height",
+                    format!(
+                        "{}{}",
+                        view.layout.height(),
+                        beyond(view.layout.y1, capture.window_size.height)
+                    ),
+                );
+                let clear = button(|| "Clear selection")
+                    .style(|s| s.margin(5.0))
+                    .on_click(move |_| selected.set(None));
+                let clear = container(clear);
+
+                v_stack((name, id, count, x, y, w, h, clear))
+                    .style(|s| s.width_full())
+                    .any()
+            } else {
+                text("No selection").style(|s| s.padding(5.0)).any()
+            }
+        },
+    )
+    .any()
+}
+
+#[derive(Clone, Copy)]
+struct CaptureView {
+    expanding_selection: RwSignal<Option<Id>>,
+    scroll_to: RwSignal<Option<Id>>,
+    selected: RwSignal<Option<Id>>,
+    highlighted: RwSignal<Option<Id>>,
+}
+
+fn capture_view(capture: &Rc<Capture>, widget: WidgetPod<Box<dyn Widget>>) -> View<impl Widget> {
+    let capture_view = CaptureView {
+        expanding_selection: create_rw_signal(None),
+        scroll_to: create_rw_signal(None),
+        selected: create_rw_signal(None),
+        highlighted: create_rw_signal(None),
+    };
+
+    let capture__ = capture.clone();
+    let window_size = capture.window_size;
+
+    let image = View::new(
+        SizedBox::new(DisplayRoot {
+            root: widget,
+            size: window_size,
+        })
+        .height(window_size.height)
+        .width(window_size.width)
+        .background(BackgroundBrush::Color(capture.background.into())),
+    );
+    let capture_ = capture.clone();
+    let selected_overlay_id = WidgetId::next();
+    let selected_overlay = empty().style(move |s| {
+        if let Some(view) = capture_view
+            .selected
+            .get()
+            .and_then(|id| capture_.root.find(id))
+        {
+            s.width(view.layout.width())
+                .height(view.layout.height())
+                .background(Color::rgb8(186, 180, 216).with_alpha(0.5))
+                .border_color(Color::rgb8(186, 180, 216).with_alpha(0.7))
+                .border(1.0)
+        } else {
+            s
+        }
+    });
+
+    let capture_ = capture.clone();
+    let highlighted_overlay_id = WidgetId::next();
+    let highlighted_overlay = empty().style(move |s| {
+        if let Some(view) = capture_view
+            .highlighted
+            .get()
+            .and_then(|id| capture_.root.find(id))
+        {
+            s.width(view.layout.width())
+                .height(view.layout.height())
+                .background(Color::rgba8(228, 237, 216, 120))
+                .border_color(Color::rgba8(75, 87, 53, 120))
+                .border(1.0)
+        } else {
+            s
+        }
+    });
+
+    let capture_ = capture.clone();
+    let image = z_stack_from_iter([
+        (image.any(), WidgetId::next(), Point::ZERO),
+        (selected_overlay.any(), selected_overlay_id, Point::ZERO),
+        (
+            highlighted_overlay.any(),
+            highlighted_overlay_id,
+            Point::ZERO,
+        ),
+    ])
+    .style(|s| {
+        s.margin(5.0)
+            .border(1.0)
+            .border_color(Color::BLACK.with_alpha(0.5))
+            .margin_bottom(21.0)
+            .margin_right(21.0)
+    })
+    .on_any_event(move |e| {
+        if let Event::MouseMove(e) = e {
+            if let Some(view) = capture_.root.find_by_pos(e.pos) {
+                if capture_view.highlighted.get() != Some(view.id) {
+                    capture_view.highlighted.set(Some(view.id));
+                }
+            } else if capture_view.highlighted.get().is_some() {
+                capture_view.highlighted.set(None);
+            }
+        }
+    })
+    .on_click(move |e| {
+        if let Event::MouseDown(e) = e {
+            if let Some(view) = capture__.root.find_by_pos(e.pos) {
+                capture_view.selected.set(Some(view.id));
+                capture_view.expanding_selection.set(Some(view.id));
+                return;
+            }
+            if capture_view.selected.get().is_some() {
+                capture_view.selected.set(None);
+            }
+        }
+    })
+    .on_leave(move || capture_view.highlighted.set(None));
+
+    let image_stack_id = image.widget_id();
+
+    let capture_ = capture.clone();
+    create_effect(move || {
+        if let Some(view) = capture_view
+            .selected
+            .get()
+            .and_then(|id| capture_.root.find(id))
+        {
+            let position = view.layout.origin();
+            update_widget::<Stack>(image_stack_id, move |mut stack| {
+                stack.set_child_position(selected_overlay_id, position)
+            });
+        }
+    });
+
+    let capture_ = capture.clone();
+    create_effect(move || {
+        if let Some(view) = capture_view
+            .highlighted
+            .get()
+            .and_then(|id| capture_.root.find(id))
+        {
+            let position = view.layout.origin();
+            update_widget::<Stack>(image_stack_id, move |mut stack| {
+                stack.set_child_position(highlighted_overlay_id, position)
+            });
+        }
+    });
+
+    let window_id = capture.window_id;
+
+    let left_scroll = scroll(
+        v_stack((
+            header("Selected View"),
+            selected_view(capture, capture_view.selected),
+            header("Stats"),
+            stats(capture),
+            button(|| "Recursive Inspection").on_click(move |_| {
+                CURRENT_RUNTIME.with(|runtime| {
+                    runtime.push_command(Command::new(INSPECT, (), Target::Window(window_id)));
+                })
+            }),
+        ))
+        .style(|s| s.min_width_full()),
+    )
+    .style(|s| {
+        s.width_full()
+            .flex_basis(0)
+            .min_height(0.0)
+            .flex_grow(1.0)
+            .flex_col()
+    });
+
+    let seperator = empty().style(move |s| {
+        s.width_full()
+            .min_height(1.0)
+            .background(Color::BLACK.with_alpha(0.2))
+    });
+
+    let left = v_stack((
+        header("Captured Window"),
+        scroll(image).style(|s| s.max_height_pct(60.0)),
+        seperator,
+        left_scroll,
+    ))
+    .style(|s| s.max_width_pct(60.0).items_start());
+
+    let tree = scroll(captured_view(&capture.root, 0, &capture_view).style(|s| s.min_width_full()))
+        .style(|s| {
+            s.width_full()
+                .min_height(0)
+                .flex_basis(0)
+                .flex_grow(1.0)
+                .flex_col()
+                .force_height_full()
+        })
+        .on_leave(move || capture_view.highlighted.set(None))
+        .on_click(move |_| capture_view.selected.set(None))
+        .scroll_to_view(move || capture_view.scroll_to.get())
+        .grow();
+
+    let tree = if capture.root.warnings() {
+        v_stack((header("Warnings"), header("View Tree"), tree))
+            .style(|s| s.items_start())
+            .any()
+    } else {
+        v_stack((header("View Tree"), tree))
+            .style(|s| s.items_start())
+            .any()
+    };
+
+    let tree = tree
+        .style(|s| {
+            s.height_full()
+                .min_width(0)
+                .flex_basis(0)
+                .flex_grow(1.0)
+                .force_width_full()
+        })
+        .grow();
+
+    let seperator = empty().style(move |s| {
+        s.height_full()
+            .min_width(1.0)
+            .width(1.0)
+            .background(Color::BLACK.with_alpha(0.2))
+    });
+
+    h_stack((left, seperator, tree))
+        .style(|s| s.height_full().width_full().max_width_full().items_start())
+}
+
+fn inspector_view(
+    capture: &Option<Rc<Capture>>,
+    widget: WidgetPod<Box<dyn Widget>>,
+) -> View<impl Widget> {
+    let view = if let Some(capture) = capture {
+        capture_view(capture, widget).any()
+    } else {
+        text("No capture").any()
+    };
+
+    container(view).style(|s| s.width_full().height_full().background(Color::WHITE))
+}
+
+pub struct DisplayRoot {
+    root: WidgetPod<Box<dyn Widget>>,
+    size: Size,
+}
+
+impl Widget for DisplayRoot {
+    fn on_event(&mut self, _ctx: &mut EventCtx, _event: &Event, _env: &Env) {}
+
+    fn on_status_change(&mut self, _ctx: &mut LifeCycleCtx, _event: &StatusChange, _env: &Env) {}
+
+    fn lifecycle(&mut self, _ctx: &mut LifeCycleCtx, _event: &LifeCycle, _env: &Env) {}
+
+    fn layout(&mut self, ctx: &mut LayoutCtx, _bc: &BoxConstraints, env: &Env) -> Size {
+        let size = self
+            .root
+            .layout(ctx, &BoxConstraints::tight(self.size), env);
+        ctx.place_child(&mut self.root, Point::ZERO, env);
+        size
+    }
+
+    fn paint(&mut self, ctx: &mut PaintCtx, env: &Env) {
+        self.root.paint(ctx, env);
+    }
+
+    fn children(&self) -> SmallVec<[WidgetRef<'_, dyn Widget>; 16]> {
+        SmallVec::new()
+    }
+}
+
+pub fn inspect(
+    widget: WidgetPod<Box<dyn Widget>>,
+    window_size: Size,
+    background: Color,
+    command_queue: &mut CommandQueue,
+    window_id: WindowId,
+) -> impl Widget {
+    let root = CapturedView::capture(widget.as_dyn(), window_size.to_rect());
+    let now = Instant::now();
+    let capture = Capture {
+        start: now,
+        post_layout: now,
+        end: now,
+        window_size,
+        window_id,
+        root: Rc::new(root),
+        background,
+    };
+    RuntimeView::new(command_queue, || {
+        inspector_view(&Some(Rc::new(capture)), widget)
+    })
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,6 +111,8 @@ mod data;
 pub mod env;
 mod event;
 pub mod ext_event;
+mod inspector;
+mod mini;
 mod mouse;
 mod platform;
 pub mod promise;

--- a/src/mini/mod.rs
+++ b/src/mini/mod.rs
@@ -1,0 +1,4 @@
+pub mod reactive;
+pub mod style;
+pub mod view;
+pub mod views;

--- a/src/mini/reactive.rs
+++ b/src/mini/reactive.rs
@@ -1,0 +1,284 @@
+use crate::command::CommandQueue;
+use crate::widget::StoreInWidgetMut;
+use crate::widget::WidgetMut;
+use crate::widget::WidgetRef;
+use crate::BoxConstraints;
+use crate::Command;
+use crate::Env;
+use crate::Event;
+use crate::EventCtx;
+use crate::LayoutCtx;
+use crate::LifeCycle;
+use crate::LifeCycleCtx;
+use crate::PaintCtx;
+use crate::Selector;
+use crate::StatusChange;
+use crate::Target;
+use crate::Widget;
+use crate::WidgetCtx;
+use crate::WidgetId;
+use crate::WidgetPod;
+use crate::WidgetState;
+use piet_common::kurbo::Point;
+use piet_common::kurbo::Size;
+use scoped_tls::scoped_thread_local;
+use slotmap::new_key_type;
+use slotmap::SlotMap;
+use smallvec::smallvec;
+use smallvec::SmallVec;
+use std::any::type_name;
+use std::cell::Cell;
+use std::collections::HashMap;
+use std::{any::Any, cell::RefCell, marker::PhantomData, rc::Rc};
+use tracing::trace_span;
+use tracing::Span;
+
+new_key_type! { struct SignalKey; }
+
+pub struct Runtime {
+    next_effect_id: Cell<u64>,
+    signals: RefCell<SlotMap<SignalKey, Signal>>,
+    current_effect: RefCell<Option<Rc<Effect>>>,
+    command_queue: RefCell<Vec<Command>>,
+}
+
+impl Runtime {
+    pub fn new() -> Self {
+        Self {
+            next_effect_id: Cell::new(0),
+            current_effect: RefCell::new(None),
+            signals: Default::default(),
+            command_queue: Default::default(),
+        }
+    }
+
+    pub fn push_command(&self, command: Command) {
+        self.command_queue.borrow_mut().push(command)
+    }
+
+    /// Forward queued commands to the real command queue.
+    fn flush_commands(&self, command_queue: &mut CommandQueue) {
+        command_queue.extend(self.command_queue.borrow_mut().drain(..))
+    }
+
+    fn as_current<R>(&self, f: impl FnOnce() -> R) -> R {
+        CURRENT_RUNTIME.set(self, f)
+    }
+}
+
+scoped_thread_local!(pub(crate) static CURRENT_RUNTIME: Runtime);
+
+pub struct RuntimeView {
+    runtime: Runtime,
+    widget: WidgetPod<Box<dyn Widget>>,
+}
+
+impl RuntimeView {
+    pub fn new<W: Widget>(command_queue: &mut CommandQueue, make_view: impl FnOnce() -> W) -> Self {
+        let runtime = Runtime::new();
+        let widget = Box::new(runtime.as_current(make_view));
+        runtime.flush_commands(command_queue);
+        Self {
+            runtime,
+            widget: WidgetPod::new(widget),
+        }
+    }
+}
+
+impl Widget for RuntimeView {
+    fn on_event(&mut self, ctx: &mut EventCtx, event: &Event, env: &Env) {
+        self.runtime
+            .as_current(|| self.widget.on_event(ctx, event, env));
+        self.runtime.flush_commands(ctx.global_state.command_queue);
+    }
+
+    fn on_status_change(&mut self, _ctx: &mut LifeCycleCtx, _event: &StatusChange, _env: &Env) {}
+
+    fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, env: &Env) {
+        self.widget.lifecycle(ctx, event, env);
+    }
+
+    fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, env: &Env) -> Size {
+        let size = self.runtime.as_current(|| {
+            let size = self.widget.layout(ctx, bc, env);
+            ctx.place_child(&mut self.widget, Point::ZERO, env);
+            size
+        });
+        self.runtime.flush_commands(ctx.global_state.command_queue);
+        size
+    }
+
+    fn paint(&mut self, ctx: &mut PaintCtx, env: &Env) {
+        self.widget.paint(ctx, env);
+    }
+
+    fn children(&self) -> SmallVec<[WidgetRef<'_, dyn Widget>; 16]> {
+        smallvec![self.widget.as_dyn()]
+    }
+
+    fn make_trace_span(&self) -> Span {
+        trace_span!("RuntimeView")
+    }
+}
+
+type UpdaterFn = Box<dyn FnOnce(UpdateWidgetArgs<'_, '_>)>;
+
+pub(crate) const UPDATE_WIDGET: Selector<RefCell<Option<UpdaterFn>>> =
+    Selector::new("masonry-builtin.mini.update-widget");
+
+pub(crate) struct UpdateWidgetArgs<'a, 'b> {
+    pub(crate) type_name: &'static str,
+    pub(crate) widget: &'a mut dyn Any,
+    pub(crate) parent_state: &'a mut WidgetState,
+    pub(crate) ctx: WidgetCtx<'a, 'b>,
+}
+
+pub fn update_widget_state(widget_id: WidgetId, f: impl FnOnce(&mut WidgetState) + 'static) {
+    CURRENT_RUNTIME.with(|runtime| {
+        let updater: RefCell<Option<UpdaterFn>> = RefCell::new(Some(Box::new(move |args| {
+            f(args.ctx.widget_state);
+        })));
+        runtime.push_command(Command::new(
+            UPDATE_WIDGET,
+            updater,
+            Target::Widget(widget_id),
+        ));
+    })
+}
+
+pub fn update_widget<W: Widget + StoreInWidgetMut>(
+    widget_id: WidgetId,
+    f: impl FnOnce(WidgetMut<'_, '_, W>) + 'static,
+) {
+    CURRENT_RUNTIME.with(|runtime| {
+        let updater: RefCell<Option<UpdaterFn>> = RefCell::new(Some(Box::new(move |args| {
+            let widget = args.widget.downcast_mut::<W>().unwrap_or_else(|| {
+                panic!(
+                    "expected to update widget with type `{}`, but found `{}` in the widget tree",
+                    type_name::<W>(),
+                    args.type_name
+                )
+            });
+            let widget_mut = WidgetMut {
+                parent_widget_state: args.parent_state,
+                inner: W::from_widget_and_ctx(widget, args.ctx),
+            };
+
+            f(widget_mut);
+        })));
+        runtime.push_command(Command::new(
+            UPDATE_WIDGET,
+            updater,
+            Target::Widget(widget_id),
+        ));
+    })
+}
+
+#[derive(Hash, Copy, Clone, Eq, PartialEq)]
+struct EffectId(u64);
+
+struct Signal {
+    value: Box<dyn Any>,
+    subscribers: HashMap<EffectId, Rc<Effect>>,
+}
+
+pub struct RwSignal<T: 'static> {
+    key: SignalKey,
+    phantom: PhantomData<T>,
+}
+
+impl<T> Copy for RwSignal<T> {}
+
+impl<T> Clone for RwSignal<T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<T: Clone> RwSignal<T> {
+    pub fn set(self, new_value: T) {
+        CURRENT_RUNTIME.with(|runtime| {
+            let subscribers: Vec<Rc<Effect>> = {
+                let mut signals = runtime.signals.borrow_mut();
+                let signal = signals.get_mut(self.key).unwrap();
+
+                *signal.value.downcast_mut::<T>().unwrap() = new_value;
+
+                signal.subscribers.values().cloned().collect()
+            };
+
+            for subscriber in subscribers {
+                subscriber.run(runtime);
+            }
+        })
+    }
+
+    pub fn get(self) -> T {
+        CURRENT_RUNTIME.with(|runtime| {
+            let effect = runtime.current_effect.borrow().clone();
+            let mut signals = runtime.signals.borrow_mut();
+            let signal = signals.get_mut(self.key).unwrap();
+            if let Some(effect) = effect {
+                effect.observers.borrow_mut().push(self.key);
+                signal.subscribers.insert(effect.id, effect);
+            }
+            signal.value.downcast_ref::<T>().unwrap().clone()
+        })
+    }
+}
+
+pub fn create_rw_signal<T>(value: T) -> RwSignal<T> {
+    CURRENT_RUNTIME.with(|runtime| RwSignal {
+        key: runtime.signals.borrow_mut().insert(Signal {
+            value: Box::new(value),
+            subscribers: HashMap::default(),
+        }),
+        phantom: PhantomData,
+    })
+}
+
+struct Effect {
+    id: EffectId,
+    run: Box<dyn Fn()>,
+    observers: RefCell<Vec<SignalKey>>,
+}
+
+impl Effect {
+    fn run(self: &Rc<Self>, runtime: &Runtime) {
+        // Remove the effect from all signals which subscribe to it.
+        {
+            let mut signals = runtime.signals.borrow_mut();
+            for observer in self.observers.borrow_mut().drain(..) {
+                if let Some(signal) = signals.get_mut(observer) {
+                    signal.subscribers.remove(&self.id);
+                }
+            }
+        }
+        *runtime.current_effect.borrow_mut() = Some(self.clone());
+        (self.run)();
+        *runtime.current_effect.borrow_mut() = None;
+    }
+}
+
+pub fn create_effect(f: impl Fn() + 'static) {
+    CURRENT_RUNTIME.with(|runtime| {
+        let id = runtime.next_effect_id.get();
+        runtime.next_effect_id.set(id + 1);
+
+        let effect = Rc::new(Effect {
+            id: EffectId(id),
+            run: Box::new(f),
+            observers: RefCell::new(Vec::new()),
+        });
+        effect.run(runtime);
+    })
+}
+
+pub fn untrack<R>(f: impl FnOnce() -> R) -> R {
+    CURRENT_RUNTIME.with(|runtime| {
+        let old = runtime.current_effect.borrow_mut().take();
+        let r = f();
+        *runtime.current_effect.borrow_mut() = old;
+        r
+    })
+}

--- a/src/mini/style.rs
+++ b/src/mini/style.rs
@@ -1,0 +1,255 @@
+use super::reactive::{create_effect, update_widget};
+use super::view::View;
+use crate::widget::CrossAxisAlignment;
+use crate::{
+    widget::{Flex, Label, SizedBox},
+    BackgroundBrush, KeyOrValue,
+};
+use piet_common::Color;
+use std::f64::INFINITY;
+
+pub const WHITE_SMOKE: Color = Color::rgba8(245, 245, 245, 255);
+pub const LIGHT_GRAY: Color = Color::rgba8(211, 211, 211, 255);
+
+#[derive(Default, Clone)]
+pub struct Style {
+    color: Option<Color>,
+    font_size: Option<f64>,
+    background: Option<Color>,
+    width: Option<f64>,
+    height: Option<f64>,
+    border: Option<f64>,
+    border_color: Option<Color>,
+    border_radius: Option<f64>,
+    grow: bool,
+    hidden: bool,
+    cross_axis_alignment: Option<CrossAxisAlignment>,
+}
+
+impl Style {
+    pub fn absolute(self) -> Self {
+        self
+    }
+
+    pub fn display(mut self, visible: bool) -> Self {
+        self.hidden = !visible;
+        self
+    }
+
+    pub fn flex_row_reverse(self) -> Self {
+        self
+    }
+
+    pub fn flex_col(self) -> Self {
+        self
+    }
+
+    pub fn flex_basis(self, _v: usize) -> Self {
+        self
+    }
+
+    pub fn flex_grow(mut self, _v: f64) -> Self {
+        self.grow = true;
+        self
+    }
+
+    pub fn font_size(mut self, v: f64) -> Self {
+        self.font_size = Some(v);
+        self
+    }
+
+    pub fn height_full(self) -> Self {
+        //self.height = Some(INFINITY);
+        self
+    }
+
+    pub fn force_height_full(mut self) -> Self {
+        self.height = Some(INFINITY);
+        self
+    }
+
+    pub fn width_full(self) -> Self {
+        //self.width = Some(INFINITY);
+        self
+    }
+
+    pub fn force_width_full(mut self) -> Self {
+        self.width = Some(INFINITY);
+        self
+    }
+
+    pub fn min_width(self, _v: impl Into<f64>) -> Self {
+        self
+    }
+
+    pub fn min_width_full(self) -> Self {
+        self
+    }
+
+    pub fn max_width_full(self) -> Self {
+        self
+    }
+
+    pub fn max_width_pct(self, _v: impl Into<f64>) -> Self {
+        self
+    }
+
+    pub fn width(mut self, v: f64) -> Self {
+        self.width = Some(v);
+        self
+    }
+
+    pub fn min_height(self, _v: impl Into<f64>) -> Self {
+        self
+    }
+
+    pub fn max_height_pct(self, _v: impl Into<f64>) -> Self {
+        self
+    }
+
+    pub fn height(mut self, v: f64) -> Self {
+        self.height = Some(v);
+        self
+    }
+
+    pub fn padding(self, _v: f64) -> Self {
+        self
+    }
+
+    pub fn padding_left(self, _v: f64) -> Self {
+        self
+    }
+
+    #[allow(unused)]
+    pub fn padding_right(self, _v: f64) -> Self {
+        self
+    }
+
+    pub fn padding_top(self, _v: f64) -> Self {
+        self
+    }
+
+    pub fn padding_bottom(self, _v: f64) -> Self {
+        self
+    }
+
+    pub fn margin(self, _v: f64) -> Self {
+        self
+    }
+
+    pub fn margin_left(self, _v: f64) -> Self {
+        self
+    }
+
+    pub fn margin_right(self, _v: f64) -> Self {
+        self
+    }
+
+    #[allow(unused)]
+    pub fn margin_top(self, _v: f64) -> Self {
+        self
+    }
+
+    pub fn margin_bottom(self, _v: f64) -> Self {
+        self
+    }
+
+    pub fn items_start(mut self) -> Self {
+        self.cross_axis_alignment = Some(CrossAxisAlignment::Start);
+        self
+    }
+
+    pub fn items_center(mut self) -> Self {
+        self.cross_axis_alignment = Some(CrossAxisAlignment::Center);
+        self
+    }
+
+    pub fn color(mut self, color: Color) -> Self {
+        self.color = Some(color);
+        self
+    }
+
+    pub fn background(mut self, color: Color) -> Self {
+        self.background = Some(color);
+        self
+    }
+
+    pub fn border(mut self, v: f64) -> Self {
+        self.border = Some(v);
+        self
+    }
+
+    pub fn border_bottom(self, _v: f64) -> Self {
+        self
+    }
+
+    pub fn border_radius(mut self, v: f64) -> Self {
+        self.border_radius = Some(v);
+        self
+    }
+
+    pub fn border_color(mut self, color: Color) -> Self {
+        self.border_color = Some(color);
+        self
+    }
+
+    pub fn apply_if(self, cond: bool, f: impl FnOnce(Self) -> Self) -> Self {
+        if cond {
+            f(self)
+        } else {
+            self
+        }
+    }
+
+    pub fn hover(self, _style: impl FnOnce(Style) -> Style) -> Self {
+        self
+    }
+}
+
+impl<W> View<W> {
+    pub fn style(self, style: impl Fn(Style) -> Style + 'static) -> Self {
+        let id = self.id();
+        create_effect(move || {
+            let style = style(Style::default());
+            update_widget::<SizedBox>(id, move |mut this| {
+                this.clear_background();
+                this.clear_border();
+                this.unset_width();
+                this.unset_height();
+
+                if let Some(background) = style.background {
+                    this.set_background(BackgroundBrush::Color(KeyOrValue::Concrete(background)));
+                }
+                this.set_visible(!style.hidden);
+                if let Some(width) = style.width {
+                    this.set_width(width);
+                }
+                if let Some(height) = style.height {
+                    this.set_height(height);
+                }
+                if let Some(width) = style.border {
+                    let color = style.border_color.unwrap_or(Color::BLACK);
+                    this.set_border(color, width);
+                }
+                this.set_rounded(style.border_radius.unwrap_or(0.0));
+
+                if let Some(color) = style.color {
+                    if let Some(mut label) = this.child_mut().unwrap().downcast::<Label>() {
+                        label.set_text_color(color)
+                    }
+                }
+                if let Some(font_size) = style.font_size {
+                    if let Some(mut label) = this.child_mut().unwrap().downcast::<Label>() {
+                        label.set_text_size(font_size);
+                    }
+                }
+                if let Some(cross_axis_alignment) = style.cross_axis_alignment {
+                    if let Some(mut flex) = this.child_mut().unwrap().downcast::<Flex>() {
+                        flex.set_cross_axis_alignment(cross_axis_alignment);
+                    }
+                }
+            });
+        });
+        self
+    }
+}

--- a/src/mini/view.rs
+++ b/src/mini/view.rs
@@ -1,0 +1,192 @@
+use crate::mini::reactive::create_effect;
+use crate::mini::reactive::{update_widget, update_widget_state};
+use crate::{
+    widget::{Portal, SizedBox, WidgetRef},
+    Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx, StatusChange, Widget,
+    WidgetId,
+};
+use crate::{BoxConstraints, WidgetPod};
+use piet_common::kurbo::{Point, Size};
+use smallvec::smallvec;
+use smallvec::SmallVec;
+use std::marker::PhantomData;
+use tracing::{trace_span, Span};
+
+type Id = WidgetId;
+
+pub type AnyView = View<Box<dyn Widget>>;
+
+pub struct View<W: 'static> {
+    pub(super) grow: bool,
+    widget: WidgetPod<SizedBox>,
+    phantom: PhantomData<W>,
+    on_any_event: Option<Box<dyn Fn(&Event)>>,
+    on_enter: Option<Box<dyn Fn()>>,
+    on_leave: Option<Box<dyn Fn()>>,
+    on_click: Option<Box<dyn Fn(&Event)>>,
+}
+
+impl<W> View<W> {
+    pub fn new(widget: W) -> Self
+    where
+        W: Widget,
+    {
+        View {
+            grow: false,
+            widget: WidgetPod::new(SizedBox::new(widget)),
+            phantom: PhantomData,
+            on_any_event: None,
+            on_enter: None,
+            on_leave: None,
+            on_click: None,
+        }
+    }
+
+    pub fn id(&self) -> WidgetId {
+        self.widget.state.id
+    }
+
+    pub fn widget_id(&self) -> WidgetId {
+        self.widget.inner.child.as_ref().unwrap().id()
+    }
+
+    pub fn grow(mut self) -> Self {
+        self.grow = true;
+        self
+    }
+
+    pub fn on_any_event(mut self, action: impl Fn(&Event) + 'static) -> Self {
+        self.on_any_event = Some(Box::new(action));
+        self
+    }
+
+    pub fn on_enter(mut self, action: impl Fn() + 'static) -> Self {
+        self.on_enter = Some(Box::new(action));
+        self
+    }
+
+    pub fn on_leave(mut self, action: impl Fn() + 'static) -> Self {
+        self.on_leave = Some(Box::new(action));
+        self
+    }
+
+    pub fn on_click(mut self, action: impl Fn(&Event) + 'static) -> Self {
+        self.on_click = Some(Box::new(action));
+        self
+    }
+
+    pub fn scroll_to_view(self, view: impl Fn() -> Option<Id> + 'static) -> Self {
+        // FIXME: This scrolling should be done after layout as there may not be a layout yet or
+        // there's pending commands that could change layout.
+        let id = self.widget_id();
+        create_effect(move || {
+            if let Some(view) = view() {
+                update_widget_state(view, move |state| {
+                    let layout = state.window_layout_rect();
+
+                    update_widget::<Portal<Box<dyn Widget>>>(id, move |mut this| {
+                        let origin = this.state().window_origin();
+                        let baseline =
+                            layout + this.last_layout_viewport_pos.to_vec2() - origin.to_vec2();
+                        this.pan_viewport_to(baseline);
+                    });
+                });
+            }
+        });
+        self
+    }
+
+    pub fn any(self) -> View<Box<dyn Widget>> {
+        View {
+            grow: self.grow,
+            widget: self.widget,
+            phantom: PhantomData,
+            on_any_event: self.on_any_event,
+            on_enter: self.on_enter,
+            on_leave: self.on_leave,
+            on_click: self.on_click,
+        }
+    }
+}
+
+impl<W> Widget for View<W> {
+    fn on_event(&mut self, ctx: &mut EventCtx, event: &Event, env: &Env) {
+        if let Some(action) = self.on_any_event.as_ref() {
+            action(event);
+        }
+        if let Event::MouseDown(_) = event {
+            if let Some(action) = self.on_click.as_ref() {
+                action(event);
+            }
+        }
+        self.widget.on_event(ctx, event, env);
+    }
+
+    fn on_status_change(&mut self, _ctx: &mut LifeCycleCtx, event: &StatusChange, _env: &Env) {
+        match event {
+            StatusChange::HotChanged(status) => {
+                if *status {
+                    if let Some(action) = self.on_enter.as_ref() {
+                        action();
+                    }
+                } else if let Some(action) = self.on_leave.as_ref() {
+                    action();
+                }
+            }
+            _ => (),
+        }
+    }
+
+    fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, env: &Env) {
+        self.widget.lifecycle(ctx, event, env);
+    }
+
+    fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, env: &Env) -> Size {
+        let size = self.widget.layout(ctx, bc, env);
+        ctx.place_child(&mut self.widget, Point::ZERO, env);
+        size
+    }
+
+    fn paint(&mut self, ctx: &mut PaintCtx, env: &Env) {
+        self.widget.paint(ctx, env);
+    }
+
+    fn children(&self) -> SmallVec<[WidgetRef<'_, dyn Widget>; 16]> {
+        smallvec![self.widget.as_dyn()]
+    }
+
+    fn make_trace_span(&self) -> Span {
+        trace_span!("View")
+    }
+}
+
+pub trait ViewSeq {
+    fn views(self) -> Vec<AnyView>;
+}
+
+macro_rules! impl_widget_sec_for_tuple {
+    ($n: tt; $($t:ident),*; $($i:tt),*; $($j:tt),*) => {
+        impl< $( $t: 'static, )* > ViewSeq for ( $( View<$t>, )* ) {
+            fn views(self) -> Vec<AnyView> {
+                vec![$(self.$i.any(),)*]
+            }
+        }
+    }
+}
+
+impl_widget_sec_for_tuple!(1; V0; 0; 0);
+impl_widget_sec_for_tuple!(2; V0, V1; 0, 1; 1, 0);
+impl_widget_sec_for_tuple!(3; V0, V1, V2; 0, 1, 2; 2, 1, 0);
+impl_widget_sec_for_tuple!(4; V0, V1, V2, V3; 0, 1, 2, 3; 3, 2, 1, 0);
+impl_widget_sec_for_tuple!(5; V0, V1, V2, V3, V4; 0, 1, 2, 3, 4; 4, 3, 2, 1, 0);
+impl_widget_sec_for_tuple!(6; V0, V1, V2, V3, V4, V5; 0, 1, 2, 3, 4, 5; 5, 4, 3, 2, 1, 0);
+impl_widget_sec_for_tuple!(7; V0, V1, V2, V3, V4, V5, V6; 0, 1, 2, 3, 4, 5, 6; 6, 5, 4, 3, 2, 1, 0);
+impl_widget_sec_for_tuple!(8; V0, V1, V2, V3, V4, V5, V6, V7; 0, 1, 2, 3, 4, 5, 6, 7; 7, 6, 5, 4, 3, 2, 1, 0);
+impl_widget_sec_for_tuple!(9; V0, V1, V2, V3, V4, V5, V6, V7, V8; 0, 1, 2, 3, 4, 5, 6, 7, 8; 8, 7, 6, 5, 4, 3, 2, 1, 0);
+impl_widget_sec_for_tuple!(10; V0, V1, V2, V3, V4, V5, V6, V7, V8, V9; 0, 1, 2, 3, 4, 5, 6, 7, 8, 9; 9, 8, 7, 6, 5, 4, 3, 2, 1, 0);
+impl_widget_sec_for_tuple!(11; V0, V1, V2, V3, V4, V5, V6, V7, V8, V9, V10; 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10; 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0);
+impl_widget_sec_for_tuple!(12; V0, V1, V2, V3, V4, V5, V6, V7, V8, V9, V10, V11; 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11; 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0);
+impl_widget_sec_for_tuple!(13; V0, V1, V2, V3, V4, V5, V6, V7, V8, V9, V10, V11, V12; 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12; 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0);
+impl_widget_sec_for_tuple!(14; V0, V1, V2, V3, V4, V5, V6, V7, V8, V9, V10, V11, V12, V13; 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13; 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0);
+impl_widget_sec_for_tuple!(15; V0, V1, V2, V3, V4, V5, V6, V7, V8, V9, V10, V11, V12, V13, V14; 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14; 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0);
+impl_widget_sec_for_tuple!(16; V0, V1, V2, V3, V4, V5, V6, V7, V8, V9, V10, V11, V12, V13, V14, V15; 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15; 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0);

--- a/src/mini/views.rs
+++ b/src/mini/views.rs
@@ -1,0 +1,108 @@
+use super::reactive::{create_effect, update_widget};
+use super::view::{AnyView, View, ViewSeq};
+use crate::mini::reactive::untrack;
+use crate::{
+    widget::{Axis, Flex, Label, Portal, SizedBox, Stack},
+    Widget, WidgetId,
+};
+use piet_common::{kurbo::Point, Color};
+use std::{any::Any, fmt::Display};
+
+pub fn text<S: Display>(text: S) -> View<impl Widget> {
+    View::new(
+        Label::new(text.to_string())
+            .with_text_color(Color::BLACK)
+            .with_text_size(12.0),
+    )
+}
+
+pub fn container(child: impl Widget) -> View<impl Widget> {
+    View::new(SizedBox::new(child))
+}
+
+pub fn empty() -> View<impl Widget> {
+    View::new(SizedBox::empty())
+}
+
+fn stack_from_iter<W: 'static>(
+    axis: Axis,
+    iterator: impl IntoIterator<Item = View<W>>,
+) -> View<impl Widget> {
+    let mut flex = Flex::for_axis(axis);
+    let iter = iterator.into_iter();
+    for child in iter {
+        if child.grow {
+            flex = flex.with_flex_child(child, 1.0)
+        } else {
+            flex = flex.with_child(child);
+        }
+    }
+    View::new(flex)
+}
+
+pub fn h_stack(children: impl ViewSeq) -> View<impl Widget> {
+    stack_from_iter(Axis::Horizontal, children.views())
+}
+
+pub fn v_stack(children: impl ViewSeq) -> View<impl Widget> {
+    stack_from_iter(Axis::Vertical, children.views())
+}
+
+/// Creates a stack from an iterator of widgets.
+#[allow(unused)]
+pub fn h_stack_from_iter<W: 'static>(
+    iterator: impl IntoIterator<Item = View<W>>,
+) -> View<impl Widget> {
+    stack_from_iter(Axis::Horizontal, iterator)
+}
+
+/// Creates a stack from an iterator of widgets.
+pub fn v_stack_from_iter<W: 'static>(
+    iterator: impl IntoIterator<Item = View<W>>,
+) -> View<impl Widget> {
+    stack_from_iter(Axis::Vertical, iterator)
+}
+
+pub fn z_stack_from_iter<W: 'static>(
+    iterator: impl IntoIterator<Item = (View<W>, WidgetId, Point)>,
+) -> View<impl Widget> {
+    let mut stack = Stack::new();
+    let iter = iterator.into_iter();
+    for (child, id, pos) in iter {
+        stack = stack.with_child_id(child, pos, id)
+    }
+    View::new(stack)
+}
+
+pub fn scroll(child: View<impl Any>) -> View<impl Widget> {
+    let child: Box<dyn Widget> = Box::new(child);
+    View::new(Portal::new(child))
+}
+
+pub fn button<S: Display + 'static>(label: impl Fn() -> S + 'static) -> View<impl Widget> {
+    container(text(label()).style(|s| {
+        s.background(Color::rgb8(240, 240, 240))
+            .padding(5.0)
+            .color(Color::rgb8(40, 40, 40))
+            .border(1.0)
+            .border_color(Color::rgb8(140, 140, 140))
+            .border_radius(5.0)
+    }))
+}
+
+pub fn dyn_container<T: Send + 'static>(
+    update_view: impl Fn() -> T + 'static,
+    child_fn: impl Fn(T) -> AnyView + 'static,
+) -> View<impl Widget> {
+    let view = empty();
+    let id = view.id();
+    create_effect(move || {
+        let value = update_view();
+        untrack(|| {
+            let widget = child_fn(value);
+            update_widget::<SizedBox>(id, |mut sized| sized.set_child(widget));
+        });
+    });
+
+    view
+}

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -25,7 +25,9 @@ mod scroll_bar;
 mod sized_box;
 mod spinner;
 mod split;
+mod stack;
 mod textbox;
+pub(crate) use stack::Stack;
 
 pub use align::Align;
 pub use button::Button;

--- a/src/widget/portal.rs
+++ b/src/widget/portal.rs
@@ -28,6 +28,10 @@ pub struct Portal<W: Widget> {
     // on re-layouts
     // TODO - rename
     viewport_pos: Point,
+
+    // FIXME: This is a hacky way to get a origin relative to this widget from a window origin.
+    pub(crate) last_layout_viewport_pos: Point,
+
     // TODO - test how it looks like
     constrain_horizontal: bool,
     constrain_vertical: bool,
@@ -45,6 +49,7 @@ impl<W: Widget> Portal<W> {
         Portal {
             child: WidgetPod::new(child),
             viewport_pos: Point::ORIGIN,
+            last_layout_viewport_pos: Point::ORIGIN,
             constrain_horizontal: false,
             constrain_vertical: false,
             must_fill: false,
@@ -310,6 +315,7 @@ impl<W: Widget> Widget for Portal<W> {
         // TODO - document better
         // Recompute the portal offset for the new layout
         self.set_viewport_pos_raw(portal_size, content_size, self.viewport_pos);
+        self.last_layout_viewport_pos = self.viewport_pos;
         // TODO - recompute portal progress
 
         ctx.place_child(&mut self.child, Point::new(0.0, -self.viewport_pos.y), env);

--- a/src/widget/stack.rs
+++ b/src/widget/stack.rs
@@ -1,0 +1,104 @@
+// This software is licensed under Apache License 2.0 and distributed on an
+// "as-is" basis without warranties of any kind. See the LICENSE file for
+// details.
+
+use crate::widget::WidgetRef;
+use crate::{
+    BoxConstraints, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx, Point,
+    Size, StatusChange, Widget, WidgetId, WidgetPod,
+};
+use smallvec::SmallVec;
+use tracing::{trace_span, Span};
+
+/// A container that stacks children at absolute positions.
+pub struct Stack {
+    children: Vec<Child>,
+}
+
+struct Child {
+    widget: WidgetPod<Box<dyn Widget>>,
+    position: Point,
+}
+
+crate::declare_widget!(StackMut, Stack);
+
+impl Stack {
+    pub fn new() -> Self {
+        Stack {
+            children: Vec::new(),
+        }
+    }
+
+    /// Builder-style method to add a child to the container.
+    pub fn with_child_id(
+        mut self,
+        child: impl Widget,
+        position: impl Into<Point>,
+        id: WidgetId,
+    ) -> Self {
+        self.children.push(Child {
+            widget: WidgetPod::new_with_id(Box::new(child), id),
+            position: position.into(),
+        });
+        self
+    }
+}
+
+// --- Mutate live Stack - WidgetMut ---
+
+impl<'a, 'b> StackMut<'a, 'b> {
+    pub fn set_child_position(&mut self, child_id: WidgetId, position: Point) {
+        if let Some(child) = self
+            .widget
+            .children
+            .iter_mut()
+            .find(|child| child.widget.id() == child_id)
+        {
+            child.position = position;
+        }
+        self.ctx.widget_state.needs_layout = true;
+    }
+}
+
+impl Widget for Stack {
+    fn on_event(&mut self, ctx: &mut EventCtx, event: &Event, env: &Env) {
+        for child in &mut self.children {
+            child.widget.on_event(ctx, event, env);
+        }
+    }
+
+    fn on_status_change(&mut self, _ctx: &mut LifeCycleCtx, _event: &StatusChange, _env: &Env) {}
+
+    fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, env: &Env) {
+        for child in &mut self.children {
+            child.widget.lifecycle(ctx, event, env);
+        }
+    }
+
+    fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, env: &Env) -> Size {
+        let mut result = Size::ZERO.to_rect();
+        for child in &mut self.children {
+            let size = child.widget.layout(ctx, bc, env).to_vec2() + child.position.to_vec2();
+            ctx.place_child(&mut child.widget, child.position, env);
+            result = result.union(size.to_size().to_rect());
+        }
+        bc.constrain(result.size())
+    }
+
+    fn paint(&mut self, ctx: &mut PaintCtx, env: &Env) {
+        for child in &mut self.children {
+            child.widget.paint(ctx, env);
+        }
+    }
+
+    fn children(&self) -> SmallVec<[WidgetRef<'_, dyn Widget>; 16]> {
+        self.children
+            .iter()
+            .map(|child| child.widget.as_dyn())
+            .collect()
+    }
+
+    fn make_trace_span(&self) -> Span {
+        trace_span!("Stack")
+    }
+}


### PR DESCRIPTION
This adds a widget inspector using a new `mini` reactive framework based on Floem. We should probably ask for a relicense of the `mini` APIs as this shares quite a lot of them.

To enable this framework there's a shared command queue (`Rc<RefCell<CommandQueue>>`) is added. A new command `UPDATE_WIDGET` is added which allows mutation of a widget given a `WidgetId` and is implemented by `WidgetPod`.

The layout of the widget inspector is quite a bit off as it's was written using Taffy's layout and `Flex` isn't sufficient to replace that. A `Stack` widget is added which stacks children in the Z direction. `SizedBox` now has a visibility property.